### PR TITLE
feat(darwin): add p6df::modules::darwin::url::open

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -13,6 +13,30 @@ p6df::modules::darwin::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::darwin::url::open(url)
+#
+#/ Synopsis
+#/    Open a URL in the default browser, cross-platform.
+#/
+#  Args:
+#	url - URL to open
+#>
+######################################################################
+p6df::modules::darwin::url::open() {
+  local url="$1" # URL to open
+
+  if command -v open >/dev/null 2>&1; then
+    open "$url"
+  else
+    xdg-open "$url"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::darwin::external::brew()
 #
 #>

--- a/init.zsh
+++ b/init.zsh
@@ -25,7 +25,7 @@ p6df::modules::darwin::deps() {
 p6df::modules::darwin::url::open() {
   local url="$1" # URL to open
 
-  if command -v open >/dev/null 2>&1; then
+  if p6_cmd_exists "open"; then
     open "$url"
   else
     xdg-open "$url"


### PR DESCRIPTION
## Summary

- Adds `p6df::modules::darwin::url::open(url)` — opens a URL in the default browser using `open` on macOS or `xdg-open` fallback on Linux, via `p6_cmd_exists`

## Why

p6df-zoom OAuth login needs to launch a browser cross-platform. Centralizing in p6df-darwin avoids raw `open` calls in zoom and keeps the macOS-specific logic in the darwin module.

## Test plan

- [ ] `p6df::modules::darwin::url::open https://example.com` opens browser on macOS
- [ ] Falls back to `xdg-open` when `open` is not in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)