### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -37,11 +37,11 @@ p6df::modules::darwin::url::open() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::darwin::external::brew()
+# Function: p6df::modules::darwin::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::darwin::external::brew() {
+p6df::modules::darwin::external::brews() {
 
   p6df::core::homebrew::cli::brew::install ack
   p6df::core::homebrew::cli::brew::install ag


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly