### PR TITLE
fix(darwin): add p6common dep, rename init to aliases::init, move synopsis block

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -7,7 +7,7 @@
 #>
 ######################################################################
 p6df::modules::darwin::deps() {
-  ModuleDeps=()
+  ModuleDeps=(p6m7g8-dotfiles/p6common)
 }
 
 ######################################################################
@@ -15,12 +15,13 @@ p6df::modules::darwin::deps() {
 #
 # Function: p6df::modules::darwin::url::open(url)
 #
+#  Args:
+#	url - URL to open
+#
+#>
 #/ Synopsis
 #/    Open a URL in the default browser, cross-platform.
 #/
-#  Args:
-#	url - URL to open
-#>
 ######################################################################
 p6df::modules::darwin::url::open() {
   local url="$1" # URL to open
@@ -69,7 +70,7 @@ p6df::modules::darwin::langs() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::darwin::init(_module, dir)
+# Function: p6df::modules::darwin::aliases::init(_module, dir)
 #
 #  Args:
 #	_module -
@@ -77,7 +78,7 @@ p6df::modules::darwin::langs() {
 #
 #>
 ######################################################################
-p6df::modules::darwin::init() {
+p6df::modules::darwin::aliases::init() {
   local _module="$1"
   local dir="$2"
 


### PR DESCRIPTION
## What
Adds `p6m7g8-dotfiles/p6common` to module deps, renames `p6df::modules::darwin::init` to `p6df::modules::darwin::aliases::init` to match the hook API, and moves the synopsis block to the correct position after `#  Args:`.

## Why
The function was registered as a generic `init` but should be an `aliases::init` hook per the updated hook API. Adding p6common as a dep ensures shared utilities are available. Synopsis position fix aligns with doc conventions.

## Test plan
- Source module and confirm `aliases::init` hook is called during module init
- Verify deps resolution includes p6common

## Dependencies
None