### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,15 +1,47 @@
 # shellcheck shell=bash
 ######################################################################
+p6df::modules::darwin::deps() {
+  ModuleDeps=(p6m7g8-dotfiles/p6common)
+}
+
+######################################################################
+p6df::modules::darwin::aliases::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_alias "c" "bat --paging=never"
+
+  p6_alias "flushdns" "sudo dscacheutil -flushcache"
+  p6_alias "whotunes" "lsof -r 2 -n -P -F n -c iTunes -a -i TCP@$(hostname):3689"
+
+  p6_return_void
+}
+######################################################################
+p6df::modules::darwin::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install ack
+  p6df::core::homebrew::cli::brew::install ag
+  p6df::core::homebrew::cli::brew::install bat
+  p6df::core::homebrew::cli::brew::install fd
+  p6df::core::homebrew::cli::brew::install rg
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::darwin::langs() {
+
+  xcode-select --install
+
+  p6_return_void
+}
+
+######################################################################
 #<
 #
 # Function: p6df::modules::darwin::deps()
 #
 #>
-######################################################################
-p6df::modules::darwin::deps() {
-  ModuleDeps=(p6m7g8-dotfiles/p6common)
-}
-
 ######################################################################
 #<
 #
@@ -42,31 +74,11 @@ p6df::modules::darwin::url::open() {
 #
 #>
 ######################################################################
-p6df::modules::darwin::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install ack
-  p6df::core::homebrew::cli::brew::install ag
-  p6df::core::homebrew::cli::brew::install bat
-  p6df::core::homebrew::cli::brew::install fd
-  p6df::core::homebrew::cli::brew::install rg
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::darwin::langs()
 #
 #>
-######################################################################
-p6df::modules::darwin::langs() {
-
-  xcode-select --install
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -77,15 +89,3 @@ p6df::modules::darwin::langs() {
 #	dir -
 #
 #>
-######################################################################
-p6df::modules::darwin::aliases::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_alias "c" "bat --paging=never"
-
-  p6_alias "flushdns" "sudo dscacheutil -flushcache"
-  p6_alias "whotunes" "lsof -r 2 -n -P -F n -c iTunes -a -i TCP@$(hostname):3689"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,9 +1,25 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::darwin::deps()
+#
+#>
+######################################################################
 p6df::modules::darwin::deps() {
   ModuleDeps=(p6m7g8-dotfiles/p6common)
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::darwin::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
 ######################################################################
 p6df::modules::darwin::aliases::init() {
   local _module="$1"
@@ -17,6 +33,12 @@ p6df::modules::darwin::aliases::init() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::darwin::external::brews()
+#
+#>
+######################################################################
 p6df::modules::darwin::external::brews() {
 
   p6df::core::homebrew::cli::brew::install ack
@@ -29,6 +51,12 @@ p6df::modules::darwin::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::darwin::langs()
+#
+#>
+######################################################################
 p6df::modules::darwin::langs() {
 
   xcode-select --install
@@ -36,12 +64,6 @@ p6df::modules::darwin::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::darwin::deps()
-#
-#>
 ######################################################################
 #<
 #
@@ -67,25 +89,3 @@ p6df::modules::darwin::url::open() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::darwin::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::darwin::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::darwin::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None