### PR TITLE
feat(darwin): add url lib helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,33 @@ TODO: Add a short summary of this module.
 
 ##### p6df-darwin/init.zsh
 
-- `p6df::modules::darwin::deps()`
-- `p6df::modules::darwin::external::brew()`
-- `p6df::modules::darwin::init(_module, dir)`
+- `p6df::modules::darwin::aliases::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
+- `p6df::modules::darwin::deps()`
+- `p6df::modules::darwin::external::brews()`
 - `p6df::modules::darwin::langs()`
+
+#### p6df-darwin/lib
+
+##### p6df-darwin/lib/url.zsh
+
+- `p6df::modules::darwin::url::open(url)`
+  - Synopsis: Open a URL in the default browser, cross-platform.
+  - Args:
+    - url - URL to open
 
 ## Hierarchy
 
 ```text
 .
 ├── init.zsh
+├── lib
+│   └── url.zsh
 └── README.md
 
-1 directory, 2 files
+2 directories, 3 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -64,28 +64,4 @@ p6df::modules::darwin::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::darwin::url::open(url)
-#
-#  Args:
-#	url - URL to open
-#
-#>
-#/ Synopsis
-#/    Open a URL in the default browser, cross-platform.
-#/
-######################################################################
-p6df::modules::darwin::url::open() {
-  local url="$1" # URL to open
-
-  if p6_cmd_exists "open"; then
-    open "$url"
-  else
-    xdg-open "$url"
-  fi
-
-  p6_return_void
-}
 

--- a/lib/url.zsh
+++ b/lib/url.zsh
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6df::modules::darwin::url::open(url)
+#
+#  Args:
+#	url - URL to open
+#
+#>
+#/ Synopsis
+#/    Open a URL in the default browser, cross-platform.
+#/
+######################################################################
+p6df::modules::darwin::url::open() {
+  local url="$1" # URL to open
+
+  if p6_cmd_exists "open"; then
+    open "$url"
+  else
+    xdg-open "$url"
+  fi
+
+  p6_return_void
+}


### PR DESCRIPTION
**What:** Add `lib/url.zsh` helper and update `init.zsh` to source it.

**Why:** Extracts macOS URL handling helpers into a dedicated lib module for better organization and reuse.

**Test plan:** Source the module in a zsh session and verify URL functions are available.

**Dependencies:** none